### PR TITLE
rebuild for missing python

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,6 @@
 {% set name = "pkgutil-resolve-name" %}
 {% set version = "1.3.10" %}
 
-
 package:
   name: {{ name|lower }}
   version: {{ version }}
@@ -11,9 +10,9 @@ source:
   sha256: 357d6c9e6a755653cfd78893817c0853af365dd51ec97f3d358a819373bbd174
 
 build:
-  number: 0
-  script: {{ PYTHON }} -m pip install . -vv
-  skip: True  # [py>38]
+  number: 1
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+
 requirements:
   host:
     - flit-core
@@ -35,6 +34,7 @@ test:
 about:
   home: https://github.com/graingert/pkgutil-resolve-name
   summary: Backport of Python 3.9's pkgutil.resolve_name; resolves a name to an object.
+  description: Backport of Python 3.9's pkgutil.resolve_name; resolves a name to an object.
   license: MIT AND PSF-2.0
   license_file: LICENSE
   license_family: PSF


### PR DESCRIPTION
pkgutil-resolve-name 1.13.0
rebuild for missing py39,310,311

**Destination channel:** defaults

### Links

- [PKG-3707]


[PKG-3707]: https://anaconda.atlassian.net/browse/PKG-3707?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ